### PR TITLE
Makefiles: update rules to be more independent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 pv2x
 pv2x-miyoo
 pv2x.cfg
-
+dist/

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ distclean:clean
 dist:all
 	mkdir -p dist/pv2x-$(VERSION)/plugins
 	mkdir -p dist/pv2x-$(VERSION)/doc
-	cp $(TARGETGP2X) dist/pv2x-$(VERSION)
+	cp $(TARGET) dist/pv2x-$(VERSION)
 	cp Vera.ttf dist/pv2x-$(VERSION)
 	cp pv2x.png dist/pv2x-$(VERSION)
 	cp README dist/pv2x-$(VERSION)

--- a/Makefile.setup
+++ b/Makefile.setup
@@ -1,6 +1,6 @@
 # SYSTEM=gp2x
-# SYSTEM=linux
-SYSTEM=miyoo
+ SYSTEM?=linux
+# SYSTEM=miyoo
 
 VERSION=1.3
 
@@ -22,7 +22,7 @@ ifeq ($(SYSTEM),linux)
 endif
 ifeq ($(SYSTEM),miyoo)
 	CPP=arm-linux-g++
-	SYSROOT=/opt/miyoo/arm-buildroot-linux-musleabi/sysroot
+	SYSROOT?=/opt/miyoo/arm-buildroot-linux-musleabi/sysroot
 	INCBASE=$(SYSROOT)/usr/include
 	LIBBASE=$(SYSROOT)/usr/lib
 	DEFINE=MIYOO


### PR DESCRIPTION
mostly when running with different SDKs and docker, also let a `linux` build be the default one, for dev purposes.

PS: the plugins works great on miyoo, from my understanding they can be accesed only from [`plugins/`](https://github.com/Apaczer/pv2x/blob/master/plugins.cpp#L11) dir.