### PR TITLE
ScaledImage: don't scale img with native res

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -143,9 +143,12 @@ int main (int argc, char **argv) {
 	SDL_Event event;
 	SDL_Surface *tmpnew;
 	SDL_Surface *tmpold;
-
-	if (img->scaledImage->w<SCREEN_WIDTH) {
-		drawoffset=(SCREEN_WIDTH-img->scaledImage->w)>>1;
+	
+	if (img->isScaled) {
+		if (img->scaledImage->w<SCREEN_WIDTH) 
+			drawoffset=(SCREEN_WIDTH-img->scaledImage->w)>>1;
+	} else if (img->image->w<SCREEN_WIDTH){
+			drawoffset=(SCREEN_WIDTH-img->image->w)>>1;
 	} else {
 		drawoffset=0;
 	}
@@ -226,10 +229,11 @@ int main (int argc, char **argv) {
 
 		sdlLock(screen);
 		SDL_FillRect(screen, NULL, 0);
-		if (img->scaledImage->w<SCREEN_WIDTH) {
-			img->blit(screen,(SCREEN_WIDTH-img->scaledImage->w)>>1,0);
+		if (img->isScaled) {	
+			if (img->scaledImage->w<SCREEN_WIDTH) 
+				img->blit(screen,(SCREEN_WIDTH-img->scaledImage->w)>>1,0);
 		} else {
-			img->blit(screen);
+				img->blit(screen,(SCREEN_WIDTH-img->image->w)>>1,0);
 		}
 		if (config.showFilename) ttf->render(screen, basen, 0, 240-ttf->getTextHeight());
 
@@ -253,9 +257,11 @@ int main (int argc, char **argv) {
 			tmpold=sdlCreateSurface(SCREEN_WIDTH,SCREEN_HEIGHT);
 			SDL_FillRect(tmpold,NULL,0);
 			img->blit(tmpold,drawoffset,0);
-
-			if (newimg->scaledImage->w<SCREEN_WIDTH) {
-				drawoffset=(SCREEN_WIDTH-newimg->scaledImage->w)>>1;
+			if (newimg->isScaled) {
+				if (newimg->scaledImage->w<SCREEN_WIDTH)
+					drawoffset=(SCREEN_WIDTH-newimg->scaledImage->w)>>1;
+			} else if (newimg->image->w<SCREEN_WIDTH) {
+				drawoffset=(SCREEN_WIDTH-newimg->image->w)>>1;
 			} else {
 				drawoffset=0;
 			}

--- a/scaledimage.cpp
+++ b/scaledimage.cpp
@@ -1,4 +1,5 @@
 #include "scaledimage.h"
+#include "defines.h"
 
 ScaledImage::ScaledImage(std::string filename, int rotateMode) {
 	this->image=NULL;
@@ -12,6 +13,9 @@ ScaledImage::ScaledImage(std::string filename, int rotateMode) {
 		this->loadError=1;
 		return;
 	}
+	
+	if ((tmpload->w==SCREEN_WIDTH && tmpload->h<=SCREEN_HEIGHT) || (tmpload->h==SCREEN_HEIGHT && tmpload->w<=SCREEN_WIDTH))
+		this->isScaled=0;
 	
 	SDL_Surface *tmp=sdlCreateSurface(tmpload->w,tmpload->h);
 	sdlLock(tmp);
@@ -73,7 +77,7 @@ ScaledImage::~ScaledImage() {
 void ScaledImage::init() {
 	this->image=NULL;
 	this->scaledImage=NULL;
-	this->isScaled=0;
+	this->isScaled=1;
 	this->loadError=0;
 }
 
@@ -84,7 +88,6 @@ void ScaledImage::scale(double factor, double angle) {
 	}
 	
 	this->scaledImage=sdlCreateSurface((int)(this->image->w*65536.0*factor)>>16, (int)(this->image->h*65536.0*factor)>>16,1);
-	this->isScaled=1;
 
 	sdlLock(this->scaledImage);
 	sdlLock(this->image);

--- a/scaledimage.cpp
+++ b/scaledimage.cpp
@@ -85,57 +85,57 @@ void ScaledImage::scale(double factor, double angle) {
 	if (this->isScaled) {
 		SDL_FreeSurface(this->scaledImage);
 		this->scaledImage=NULL;
+		this->scaledImage=sdlCreateSurface((int)(this->image->w*65536.0*factor)>>16, (int)(this->image->h*65536.0*factor)>>16,1);
 	}
 	
-	this->scaledImage=sdlCreateSurface((int)(this->image->w*65536.0*factor)>>16, (int)(this->image->h*65536.0*factor)>>16,1);
-
-	sdlLock(this->scaledImage);
 	sdlLock(this->image);
-	
 	Uint16 *src=(Uint16*)this->image->pixels;
-	Uint16 *dst=(Uint16*)this->scaledImage->pixels;
 	
-	int sinfp=(int)((sin(angle)*65536.0)/factor);
-        int cosfp=(int)((cos(angle)*65536.0)/factor);
+	if (this->isScaled) {
+		sdlLock(this->scaledImage);
+		Uint16 *dst=(Uint16*)this->scaledImage->pixels;
+		
+		int sinfp=(int)((sin(angle)*65536.0)/factor);
+		int cosfp=(int)((cos(angle)*65536.0)/factor);
 
-        int xc=(this->image->w<<15) - ((this->scaledImage->w>>1)*(cosfp+sinfp));
-        int yc=(this->image->h<<15) - ((this->scaledImage->h>>1)*(cosfp-sinfp));
+		int xc=(this->image->w<<15) - ((this->scaledImage->w>>1)*(cosfp+sinfp));
+		int yc=(this->image->h<<15) - ((this->scaledImage->h>>1)*(cosfp-sinfp));
 
-        int tx,ty;
-        int x,y;
-        int tempx,tempy;
-        int lasttempx=0, lasttempy=0;
-        int colorcount;
-        int ipx,ipy;
-        Uint8 r,g,b;
-        int rsum=0,gsum=0,bsum=0;
-        Uint32 newpixel;
-        int scaledpitch=this->scaledImage->pitch>>1;
-	int imagepitch=this->image->pitch>>1;
+		int tx,ty;
+		int x,y;
+		int tempx,tempy;
+		int lasttempx=0, lasttempy=0;
+		int colorcount;
+		int ipx,ipy;
+		Uint8 r,g,b;
+		int rsum=0,gsum=0,bsum=0;
+		Uint32 newpixel;
+		int scaledpitch=this->scaledImage->pitch>>1;
+		int imagepitch=this->image->pitch>>1;
 
-        for ( y=0; y<this->scaledImage->h; y++ ) {
+		for ( y=0; y<this->scaledImage->h; y++ ) {
 
-                tx=xc;
-                ty=yc;
+				tx=xc;
+				ty=yc;
 
-                for( x=0; x<this->scaledImage->w; x++ ) {
+				for( x=0; x<this->scaledImage->w; x++ ) {
 
-                        tempx=(tx>>16);
-                        tempy=(ty>>16);
+						tempx=(tx>>16);
+						tempy=(ty>>16);
 
-                        if( (tempx<0) || (tempx>=this->image->w) || (tempy<0) || (tempy>=this->image->h) ) {
-                                *dst = 0;
-                        } else {
-                                if (
+						if( (tempx<0) || (tempx>=this->image->w) || (tempy<0) || (tempy>=this->image->h) ) {
+								*dst = 0;
+						} else {
+								if (
 					(tempx-lasttempx>0) ||
 					(tempy-lasttempy>0)
 				) {
 					rsum=0;
 					gsum=0;
 					bsum=0;
-	                                colorcount=0;
-	                                ipy=0;
-	                                for (ipy=0;ipy<(tempy-lasttempy)+1;ipy++) {
+									colorcount=0;
+									ipy=0;
+									for (ipy=0;ipy<(tempy-lasttempy)+1;ipy++) {
 						for (ipx=0;ipx<(tempx-lasttempx)+1;ipx++) {
 							SDL_GetRGB(*(src+tempx-ipx+((tempy-ipy)*imagepitch)),this->image->format,&r,&g,&b);
 							rsum+=r;
@@ -154,21 +154,21 @@ void ScaledImage::scale(double factor, double angle) {
 				} else {
 					*(dst+x+y*scaledpitch) = *(src+tempx+tempy*imagepitch);
 				}
-                        }
+						}
 
-                        tx+=cosfp;
-                        ty-=sinfp;
+						tx+=cosfp;
+						ty-=sinfp;
 
-                        lasttempx=tempx;
-                        lasttempy=tempy;
-                }
-                lasttempx=0;
-                xc+=sinfp;
-                yc+=cosfp;
-        }
-
+						lasttempx=tempx;
+						lasttempy=tempy;
+				}
+				lasttempx=0;
+				xc+=sinfp;
+				yc+=cosfp;
+			}
+		sdlUnlock(this->scaledImage);
+		}
 	sdlUnlock(this->image);
-	sdlUnlock(this->scaledImage);
 }
 
 void ScaledImage::blit(SDL_Surface *target) {


### PR DESCRIPTION
what anoyed me from the beginning is that the `pv2x` tries to downscale the img even with 1:1 size (same as screen).

Let's make scaling conditional, and not set to true (`isScaled=1`) all the time.